### PR TITLE
Add Node.js 18 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20, 22]
+        node-version: [18, 20, 22]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20, 22]
+        node-version: [18, 20, 22]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A robust command-line tool for creating timestamped RAR backups with advanced ig
 
 ## Prerequisites
 
-- **Node.js** 20 or higher
+- **Node.js** 18 or higher
 - **RAR command-line tool** must be installed and available in PATH
 
 ## Installation

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO
 
 - Fix the typescript sutiation.
-- Add support for more Node.js versions.
 
 # Research legacy behavior
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@arabasta/eslint-config": "^1.0.8",
-        "@types/node": "^20.17.58",
+        "@types/node": "^18.19.67",
         "cross-env": "^7.0.3",
         "dotenv": "^16.5.0",
         "eslint": "^8.57.1",
@@ -29,7 +29,7 @@
         "vitest": "^3.2.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@arabasta/eslint-config": {
@@ -1164,13 +1164,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "18.19.112",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
+      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7058,9 +7058,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "command-line"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist",
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@arabasta/eslint-config": "^1.0.8",
-    "@types/node": "^20.17.58",
+    "@types/node": "^18.19.67",
     "cross-env": "^7.0.3",
     "dotenv": "^16.5.0",
     "eslint": "^8.57.1",


### PR DESCRIPTION
This pull request updates the project to support Node.js version 18 and adjusts related configurations and documentation accordingly. The most important changes include modifying version requirements in workflow files, documentation, and `package.json`, as well as updating TypeScript definitions to align with the new Node.js version support.

### Node.js version support updates:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L19-R19): Updated the `node-version` matrix to include Node.js 18 alongside versions 20 and 22.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R19): Updated the `node-version` matrix to include Node.js 18 alongside versions 20 and 22.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19): Changed the prerequisites to specify Node.js 18 or higher instead of 20 or higher.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R26): Updated the `engines.node` field to require Node.js version 18 or higher.

### TypeScript definitions update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58-R58): Updated `@types/node` dependency to a version compatible with Node.js 18 (`^18.19.67`).