### PR TITLE
Add Node.js 19, 21, 23 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18, 20, 22]
+        node-version: [18, 19, 20, 21, 22, 23, 24]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22' #  Use the latest active LTS version
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18, 20, 22]
+        node-version: [18, 19, 20, 21, 22, 23, 24]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20, 22]
+        node-version: [18, 19, 20, 21, 22, 23, 24]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
This pull request updates the Node.js versions used in the GitHub Actions workflows to include additional versions, ensuring broader compatibility and testing coverage. It also adds a comment clarifying the use of the latest active LTS version in the `publish.yml` workflow.

### Node.js version updates:
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L19-R19): Expanded the `node-version` matrix to include versions 19, 21, 23, and 24.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R19): Updated the `node-version` matrix in multiple places to include versions 19, 21, 23, and 24, ensuring consistency across testing configurations. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R19) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L75-R75)

### Workflow clarification:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L24-R24): Added a comment specifying that Node.js version 22 is the latest active LTS version.